### PR TITLE
update for use with terraform v0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,8 +121,8 @@ resource "aws_eks_cluster" "polkadot" {
   version  = var.k8s_version
 
   vpc_config {
-    security_group_ids = ["${aws_security_group.polkadot.id}"]
-    subnet_ids         = flatten(["${aws_subnet.polkadot.*.id}"])
+    security_group_ids = [aws_security_group.polkadot.id]
+    subnet_ids         = flatten([aws_subnet.polkadot.*.id])
   }
 
   depends_on = [
@@ -304,7 +304,7 @@ resource "aws_autoscaling_group" "polkadot" {
   max_size             = 32
   min_size             = 1
   name                 = "polkadot-${var.cluster_name}"
-  vpc_zone_identifier  = flatten(["${aws_subnet.polkadot.*.id}"])
+  vpc_zone_identifier  = flatten([aws_subnet.polkadot.*.id])
 
   tag {
     key                 = "Name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,12 +44,12 @@ KUBECONFIG
 
 output "config_map_aws_auth" {
   description = "A kubernetes configuration to authenticate to this EKS cluster"
-  value       = "${local.config_map_aws_auth}"
+  value       = local.config_map_aws_auth
   sensitive   = true
 }
 
 output "kubeconfig" {
   description = "kubectl config file contents for this EKS cluster"
-  value       = "${local.kubeconfig}"
+  value       = local.kubeconfig
   sensitive   = true
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,8 +1,7 @@
 provider "aws" {
+  profile  = var.profile
   region  = var.location
-  version = "~>2.28"
 }
 
 provider "null" {
-  version = "~>2.1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "location" {
   type        = string
 }
 
+variable "profile" {
+  description = "AWS profile"
+  type        = string
+}
+
 variable "node_count" {
   description = "Size of EKS cluster"
   default     = 2
@@ -23,6 +28,6 @@ variable "machine_type" {
 
 variable "k8s_version" {
   description = "Kubernetes version to use for the EKS cluster"
-  default     = "1.15"
+  default     = "1.21"
   type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,13 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+    null = {
+      source = "hashicorp/null"
+      version = "~>3.1"
+    }
+  }
 }


### PR DESCRIPTION
in my efforts to use this module with a recent version of terraform, i encountered errors on `terraform plan` relating to changes in how latest terraform expects specific configuration to differ.
specifically:
* provider `version` is now specified in the `required_providers` configuration block rather than in the `provider` configuration block
* interpolation-only expressions are deprecated, non-constant expressions should no longer be specified with interpolation syntax

i also added a provider profile variable, which optionally allows passing the aws credentials in this format.